### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -31,6 +31,8 @@ jobs:
 
   jupyter:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read          # Minimal permissions for read-only operations
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: tschm/cradle/actions/environment@v0.1.71


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/MosekRegression/security/code-scanning/4](https://github.com/tschm/MosekRegression/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the `jupyter` job. Since the job does not appear to require write permissions, we can set the permissions to `contents: read`, which is the minimal permission required for most read-only operations. This ensures that the job adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
