### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: "CI"
 on:
 - push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # The type of runner that the job will run on


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/MosekRegression/security/code-scanning/2](https://github.com/tschm/MosekRegression/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the tasks described (building a virtual environment and running tests), the workflow likely only needs `contents: read` permissions. If additional permissions are required for specific tasks, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
