### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -20,6 +20,8 @@ jobs:
 
   test:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read          # Minimal permissions for read-only operations
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: tschm/cradle/actions/environment@v0.1.72


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/MosekRegression/security/code-scanning/3](https://github.com/tschm/MosekRegression/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `test` job in the workflow file. The permissions should be limited to the least privileges required for the job to function correctly. Since the `test` job appears to involve running tests and generating coverage reports, it likely only requires read access to the repository contents. 

The `permissions` block should be added directly under the `runs-on` key for the `test` job. The minimal permissions required are:
- `contents: read` for read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
